### PR TITLE
Refactored test_alerts.py, test_modal_dialog.py

### DIFF
--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,8 +1,36 @@
 import pytest
+from core.settings import Config
+from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
+
+@pytest.fixture(scope="session")
+def config():
+    return Config.load()
+
+@pytest.fixture(scope="function")
+def driver(config):
+    match config.browser.NAME:
+        case "chrome":
+            from selenium.webdriver.chrome.options import Options
+            options = Options()
+            options.page_load_strategy="none"
+            for argument in config.browser.OPTIONS_CHROME.split(';'):
+                options.add_argument(argument)
+            driver = webdriver.Chrome(options=options)
+        case "edge":
+            from selenium.webdriver.edge.options import Options
+            options = Options()
+            for argument in config.browser.OPTIONS_EDGE.split(';'):
+                options.add_argument(argument)
+            driver = webdriver.Edge(options=options)
+        case _:
+            raise RuntimeError(f"Browser {config.browser.NAME} is not supported.")
+    driver.implicitly_wait(3)
+    yield driver
+    driver.quit()
 
 @pytest.fixture
 def alerts(driver):
@@ -10,18 +38,24 @@ def alerts(driver):
     return driver
 
 def test_see_alert(alerts):
+    waiter5 = WebDriverWait(alerts, 5)
+    waiter5.until(EC.visibility_of_element_located((By.ID, "alertButton")))
     alerts.find_element(By.ID, "alertButton").click()
 
     assert alerts.switch_to.alert.text == "You clicked a button", "Alert isn't present"
 
 def test_timer_alert(alerts):
-    waiter6 = WebDriverWait(alerts, 10)
+    waiter10 = WebDriverWait(alerts, 10)
+    waiter5 = WebDriverWait(alerts, 5)
+    waiter5.until(EC.visibility_of_element_located((By.ID, "timerAlertButton")))
     alerts.find_element(By.ID, "timerAlertButton").click()
-    waiter6.until(EC.alert_is_present())
+    waiter10.until(EC.alert_is_present())
 
     assert alerts.switch_to.alert.text == "This alert appeared after 5 seconds", "Alert isn't present"
 
 def test_confirm_box_alert(alerts):
+    waiter5 = WebDriverWait(alerts, 5)
+    waiter5.until(EC.visibility_of_element_located((By.ID, "confirmButton")))
     alerts.find_element(By.ID, "confirmButton").click()
     alert = alerts.switch_to.alert
 
@@ -33,6 +67,8 @@ def test_confirm_box_alert(alerts):
     assert confirm_text == "You selected Ok"
 
 def test_prompt_box(alerts):
+    waiter5 = WebDriverWait(alerts, 5)
+    waiter5.until(EC.visibility_of_element_located((By.ID, "promtButton")))
     test_text = "Testing prompt box..."
     alerts.find_element(By.ID, "promtButton").click()
 

--- a/tests/test_modal_dialog.py
+++ b/tests/test_modal_dialog.py
@@ -1,8 +1,36 @@
 import pytest
+from core.settings import Config
+from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
+
+@pytest.fixture(scope="session")
+def config():
+    return Config.load()
+
+@pytest.fixture(scope="function")
+def driver(config):
+    match config.browser.NAME:
+        case "chrome":
+            from selenium.webdriver.chrome.options import Options
+            options = Options()
+            options.page_load_strategy="none"
+            for argument in config.browser.OPTIONS_CHROME.split(';'):
+                options.add_argument(argument)
+            driver = webdriver.Chrome(options=options)
+        case "edge":
+            from selenium.webdriver.edge.options import Options
+            options = Options()
+            for argument in config.browser.OPTIONS_EDGE.split(';'):
+                options.add_argument(argument)
+            driver = webdriver.Edge(options=options)
+        case _:
+            raise RuntimeError(f"Browser {config.browser.NAME} is not supported.")
+    driver.implicitly_wait(3)
+    yield driver
+    driver.quit()
 
 @pytest.fixture
 def modal(driver):
@@ -19,6 +47,7 @@ def modal(driver):
 )
 def test_modal_dialog(modal, body_text, id_show, id_button, title):
     waiter5 = WebDriverWait(modal, 5)
+    waiter5.until(EC.visibility_of_element_located((By.ID, id_show)))
     modal.find_element(By.ID, id_show).click()
     waiter5.until(EC.presence_of_element_located((By.XPATH, '//div[@role="dialog"]')))
     modal.switch_to.active_element.find_element(By.XPATH, '//div[@role="dialog"]')


### PR DESCRIPTION
В этих 2-х тестах изменил стратегию: тестирование начинается не ожидая полной загрузки DOM, а как только будет загружен первый доступный элемент, с которого начинается тестирование. Для этого добавил в Chrome option:
options.page_load_strategy="none"