### PR TITLE
add test_new_job_opens_from_create_job_block

### DIFF
--- a/tests/wecome_dashboard/conftest.py
+++ b/tests/wecome_dashboard/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+
+@pytest.fixture(scope="function")
+def new_item_page_opens_after_clicking_create_job_block(main_page, config):
+    wait5 = WebDriverWait(main_page, 5)
+    wait5.until(EC.presence_of_element_located((By.XPATH, "//*[text()='Create a job']"))).click()
+    return main_page
+
+
+@pytest.fixture(scope="function")
+def new_item_page_opens_after_clicking_plus_in_create_job_block(main_page, config):
+    wait5 = WebDriverWait(main_page, 5)
+    main_page.find_elements(By.CSS_SELECTOR, '.trailing-icon')[0].click()
+    return main_page

--- a/tests/wecome_dashboard/test_new_job_opens_from_create_job_block.py
+++ b/tests/wecome_dashboard/test_new_job_opens_from_create_job_block.py
@@ -1,0 +1,7 @@
+def test_new_item_page_opens_after_clicking_create_job_block(new_item_page_opens_after_clicking_create_job_block):
+    assert new_item_page_opens_after_clicking_create_job_block.title == "New Item [Jenkins]"
+
+
+def test_new_item_page_opens_after_clicking_plus_in_create_job_block(
+        new_item_page_opens_after_clicking_plus_in_create_job_block):
+    assert new_item_page_opens_after_clicking_plus_in_create_job_block.current_url == "http://localhost:8080/newJob"


### PR DESCRIPTION
[379-tc_11002-welcome-dashboard-create-a-job-verify-that-new-item-page-opens](https://github.com/RedRoverSchool/JenkinsQA_Python_2025_spring/tree/379-tc_11002-welcome-dashboard-create-a-job-verify-that-new-item-page-opens)