### PR TITLE
TC_04.002.02 | Multi-configuration project Configuration > Edit Project Description

### DIFF
--- a/tests/Multi_configuration/conftest.py
+++ b/tests/Multi_configuration/conftest.py
@@ -16,3 +16,22 @@ def multi_config_project_page(main_page):
     wait.until(EC.element_to_be_clickable((By.ID, "ok-button"))).click()
     wait.until(EC.presence_of_element_located((By.NAME, "description")))
     return main_page
+
+
+@pytest.fixture
+def multi_config_project_with_description_page(main_page):
+    wait = WebDriverWait(main_page, 10)
+    project_name = "MultiConfigProject02"
+    description = "This is my overview"
+
+    wait.until(EC.element_to_be_clickable((By.LINK_TEXT, "New Item"))).click()
+    wait.until(EC.presence_of_element_located((By.ID, "name"))).send_keys(project_name)
+    wait.until(EC.element_to_be_clickable(
+        (By.XPATH, '//*[@id="j-add-item-type-standalone-projects"]/ul/li[3]/div[2]/div'))).click()
+    wait.until(EC.element_to_be_clickable((By.ID, "ok-button"))).click()
+    wait.until(EC.presence_of_element_located((By.NAME, "description"))).send_keys(description)
+    main_page.find_element(By.NAME, "Submit").click()
+    wait.until(EC.presence_of_element_located((By.LINK_TEXT, project_name)))
+    project_link = main_page.find_element(By.LINK_TEXT, project_name)
+    project_link.click()
+    return main_page

--- a/tests/Multi_configuration/test_edit_description.py
+++ b/tests/Multi_configuration/test_edit_description.py
@@ -1,0 +1,24 @@
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+import time
+
+
+def test_edit_description_from_project_page(multi_config_project_with_description_page):
+    wait = WebDriverWait(multi_config_project_with_description_page, 10)
+    updated_text = "Updated project summary"
+
+    wait.until(EC.element_to_be_clickable((By.XPATH, '//*[@id="description-link"]'))).click()
+    desc_input = wait.until(EC.presence_of_element_located((By.NAME, "description")))
+    desc_input.clear()
+    desc_input.send_keys(updated_text)
+    multi_config_project_with_description_page.find_element(By.NAME, "Submit").click()
+    for _ in range(2):
+        try:
+            desc_element = wait.until(EC.presence_of_element_located((By.ID, "description")))
+            assert updated_text in desc_element.text, f"Expected '{updated_text}', but got '{desc_element.text}'"
+            break
+        except Exception:
+            time.sleep(1)  # микропаузу на случай лагов
+    else:
+        raise AssertionError("Description was not updated properly after 2 tries.")


### PR DESCRIPTION
This PR introduces a new automated test to validate that users can edit the description of a multi-configuration project directly from the project page (not the config page)

Description edit using the "Edit description" button

Revalidation using updated text

Retry logic to avoid flaky StaleElementReferenceException