### PR TITLE
Open system information page

### DIFF
--- a/tests/display_system_information/base_methods.py
+++ b/tests/display_system_information/base_methods.py
@@ -9,9 +9,6 @@ class BaseMethods:
     TIMEOUT = 5
     POLL_FREQUENCY = 0.5
 
-    endpoint_url = ""
-    tab_title = ""
-
     def __init__(self, main_page: WebDriver):
         self.driver = main_page
         self.base_url = main_page.current_url
@@ -24,14 +21,6 @@ class BaseMethods:
             return result if element_flag else True
         except TimeoutException:
             return None if element_flag else False
-
-    def open(self):
-        target_url = self.base_url + self.endpoint_url
-        self.driver.get(target_url)
-        if hasattr(self, "tab_title"):
-            self.safe_wait(EC.title_is(self.tab_title))
-        else:
-            self.safe_wait(lambda d: self.endpoint_url in d.current_url if self.endpoint_url else self.base_url in d.current_url)
 
     def click(self, locator: tuple[str, str]):
         self.wait.until(EC.element_to_be_clickable(locator)).click()

--- a/tests/display_system_information/base_methods.py
+++ b/tests/display_system_information/base_methods.py
@@ -1,0 +1,40 @@
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.remote.webelement import WebElement
+from selenium.common import TimeoutException
+
+
+class BaseMethods:
+    TIMEOUT = 5
+    POLL_FREQUENCY = 0.5
+
+    endpoint_url = ""
+    tab_title = ""
+
+    def __init__(self, main_page: WebDriver):
+        self.driver = main_page
+        self.base_url = main_page.current_url
+        self.wait = WebDriverWait(main_page, BaseMethods.TIMEOUT, poll_frequency=BaseMethods.POLL_FREQUENCY)
+
+    def safe_wait(self, condition: callable, timeout: int = None, element_flag: bool = False) -> bool | WebElement | None:
+        wait = self.wait if timeout is None else WebDriverWait(self.driver, timeout, poll_frequency=BaseMethods.POLL_FREQUENCY)
+        try:
+            result = wait.until(condition)
+            return result if element_flag else True
+        except TimeoutException:
+            return None if element_flag else False
+
+    def open(self):
+        target_url = self.base_url + self.endpoint_url
+        self.driver.get(target_url)
+        if hasattr(self, "tab_title"):
+            self.safe_wait(EC.title_is(self.tab_title))
+        else:
+            self.safe_wait(lambda d: self.endpoint_url in d.current_url if self.endpoint_url else self.base_url in d.current_url)
+
+    def click(self, locator: tuple[str, str]):
+        self.wait.until(EC.element_to_be_clickable(locator)).click()
+
+    def is_visible(self, locator: tuple[str, str]) -> bool:
+        return self.safe_wait(EC.visibility_of_element_located(locator))

--- a/tests/display_system_information/locators.py
+++ b/tests/display_system_information/locators.py
@@ -1,0 +1,13 @@
+from selenium.webdriver.common.by import By
+
+
+class JenkinsSidePanel:
+    MANAGE_JENKINS = (By.XPATH, "//div[@class='task '][.//span[text()='Manage Jenkins']]")
+
+
+class ManageJenkinsTask:
+    SYSTEM_INFORMATION = (By.XPATH, "//a[@href='systemInfo']/..")
+
+
+class SystemInformationPage:
+    TABS_BAR = (By.CSS_SELECTOR, '.tabBar')

--- a/tests/display_system_information/test_system_information_section.py
+++ b/tests/display_system_information/test_system_information_section.py
@@ -1,0 +1,13 @@
+from tests.display_system_information.base_methods import BaseMethods
+from tests.display_system_information.locators import (
+    JenkinsSidePanel as SP,
+    ManageJenkinsTask as MJ,
+    SystemInformationPage as SI)
+
+
+class TestSystemInformationSection:
+    def test_open_system_information_page(self, main_page):
+        page = BaseMethods(main_page)
+        page.click(SP.MANAGE_JENKINS)
+        page.click(MJ.SYSTEM_INFORMATION)
+        assert page.is_visible(SI.TABS_BAR)


### PR DESCRIPTION
**TC_10.019.01 | Manage Jenkins > Display System Information > Open "System Information" Page**

**Preconditions:**
The user is logged into Jenkins and located on the Dashboard page.

**Description:**
Verify that the "System Information" page is accessible via the "Manage Jenkins" task.

**Steps:**

1. Click on the "Manage Jenkins" task.
2. On the opened page, click on the "System Information" item.

**Expected Result:**
The user is successfully redirected to the "System Information" page.

**Acceptence** Criteria:

1. The user should be able to navigate to Manage Jenkins and see the "System Information" option.
2. Clicking on "System Information" opens a page with multiple tabs