### PR TITLE
TC_10.019.05 | Manage Jenkins > Display System Information > Show/hide each single value on the "Environment Variables" tab

### DIFF
--- a/tests/display_system_information/test_system_information_section.py
+++ b/tests/display_system_information/test_system_information_section.py
@@ -55,3 +55,18 @@ class TestSystemInformationSection:
         for element_name in element_names:
             button_locator = page.define_show_single_value_button_locator(element_name)
             assert page.is_clickable(button_locator), f'Button for {element_name} is not clickable'
+
+    def test_environment_variables_tab_show_hide_each_single_value(self, sys_info_page):
+        page = SIP(sys_info_page)
+        page.click(SI.ENVIRONMENT_VARIABLES_TAB)
+        element_names = page.get_all_element_names(SI.SHOW_ENV_VALUES_BUTTON)
+        assert len(element_names) > 0, 'List of environment variables is empty'
+
+        for element_name in element_names:
+            show_button = page.define_show_single_value_button_locator(element_name)
+            page.click(show_button)
+            assert page.is_value_displayed(element_name), f'Value for {element_name} is still hidden'
+
+            hide_button = page.define_hide_single_value_button_locator(element_name)
+            page.click(hide_button)
+            assert page.is_clickable(show_button), f'Button for {element_name} is not clickable'


### PR DESCRIPTION
**TC_10.019.05 | Manage Jenkins > Display System Information > Show/hide each single value on the "Environment Variables" tab**

**Preconditions:**
- The user is logged into Jenkins and located on the "System Information" page.
- The active tab is the "Environment Variables" tab, all values are hidden.

**Description:**
Verify that the individual show/hide value buttons work properly for each name on the "Environment Variables" tab.

**Steps:**
1. Click on the "Hidden value, click to show this value" button across the first name.
2. Check that this hidden value became visible.
3. Click on this visible value.
4. Check that this value has become hidden.
5. Repeat steps 1-4 for the rest names, one by one.

**Expected Result:**
All existing values on the "Environment Variables" tab, one by one, became visible and then hidden.

**Acceptance Criteria:**
The user should be able to show/hide values in System Properties and Environment Variables data.