### PR TITLE
TC_10.019.06 | Manage Jenkins > Display System Information > "Plugins" tab - display information about installed plugins

### DIFF
--- a/tests/display_system_information/base_methods.py
+++ b/tests/display_system_information/base_methods.py
@@ -50,7 +50,7 @@ class BaseMethods:
     def get_element(self, locator: tuple[str, str]) -> WebElement | None:
         return self.safe_wait(EC.presence_of_element_located(locator), element_flag=True)
 
-    def element_text(self, locator: tuple[str, str]) -> str:
+    def get_element_text(self, locator: tuple[str, str]) -> str:
         element = self.safe_wait(EC.visibility_of_element_located(locator), element_flag=True)
         return element.text.strip() if element else ''
 

--- a/tests/display_system_information/base_methods.py
+++ b/tests/display_system_information/base_methods.py
@@ -52,5 +52,5 @@ class BaseMethods:
 
     def element_text(self, locator: tuple[str, str]) -> str:
         element = self.safe_wait(EC.visibility_of_element_located(locator), element_flag=True)
-        return element.text
+        return element.text.strip() if element else ''
 

--- a/tests/display_system_information/base_methods.py
+++ b/tests/display_system_information/base_methods.py
@@ -50,3 +50,7 @@ class BaseMethods:
     def get_element(self, locator: tuple[str, str]) -> WebElement | None:
         return self.safe_wait(EC.presence_of_element_located(locator), element_flag=True)
 
+    def element_text(self, locator: tuple[str, str]) -> str:
+        element = self.safe_wait(EC.visibility_of_element_located(locator), element_flag=True)
+        return element.text
+

--- a/tests/display_system_information/base_methods.py
+++ b/tests/display_system_information/base_methods.py
@@ -31,9 +31,22 @@ class BaseMethods:
     def is_clickable(self, locator: tuple[str, str]) -> bool:
         return self.safe_wait(EC.element_to_be_clickable(locator))
 
+    def is_link_clickable(self, locator: tuple[str, str]) -> bool:
+        element = self.get_element(locator)
+        if not element:
+            return False
+        if element.tag_name.lower() != 'a':
+            return False
+        href = element.get_attribute('href')
+        return element.is_displayed() and bool(href)
+
     def find_element(self, locator: tuple[str, str]) -> WebElement:
         return self.safe_wait(EC.visibility_of_element_located(locator), element_flag=True)
 
     def get_attribute(self,  attribute: str, locator: tuple[str, str]) -> str:
         element = self.safe_wait(EC.presence_of_element_located(locator), element_flag=True)
         return element.get_attribute(attribute)
+
+    def get_element(self, locator: tuple[str, str]) -> WebElement | None:
+        return self.safe_wait(EC.presence_of_element_located(locator), element_flag=True)
+

--- a/tests/display_system_information/locators.py
+++ b/tests/display_system_information/locators.py
@@ -20,3 +20,4 @@ class SystemInformationPage:
     SHOW_ENV_VALUES_BUTTON = (By.XPATH, "(//button[contains(normalize-space(text()), 'Show values')])[2]")
     HIDE_SYS_VALUES_BUTTON = (By.XPATH, "(//button[contains(normalize-space(text()), 'Hide values')])[1]")
     HIDE_ENV_VALUES_BUTTON = (By.XPATH, "(//button[contains(normalize-space(text()), 'Hide values')])[2]")
+    PLUGINS_TABLE_BODY = (By.XPATH, "(//table[@class='jenkins-table sortable'])[3]/tbody")

--- a/tests/display_system_information/system_information_page.py
+++ b/tests/display_system_information/system_information_page.py
@@ -29,6 +29,7 @@ class SystemInformationPage(BaseMethods):
         return first_td_values
 
     def get_all_element_names(self, anchor_locator):
+        # for System Properties and Environment Variables tabs only
         data_table_id = self.get_data_table_id(anchor_locator)
         return self.get_table_td_values(data_table_id)
 

--- a/tests/display_system_information/system_information_page.py
+++ b/tests/display_system_information/system_information_page.py
@@ -49,3 +49,14 @@ class SystemInformationPage(BaseMethods):
 
     def find_table_element(self, table_id: str) -> WebElement:
         return self.find_element((By.ID, table_id))
+
+    def number_of_plugins_in_table(self, table_body_locator: tuple[str, str]) -> int:
+        table = self.find_element(table_body_locator)
+        return len(table.find_elements(By.TAG_NAME, "tr"))
+
+    def get_plugin_info(self, number: int) -> tuple[tuple[str, str], tuple[str, str], tuple[str, str], str]:
+        name_locator = (By.XPATH, f"(//table[@class='jenkins-table sortable'])[3]/tbody/tr[{number}]/td[1]//a")
+        version_locator = (By.XPATH, f"(//table[@class='jenkins-table sortable'])[3]/tbody/tr[{number}]/td[2]")
+        enabled_locator = (By.XPATH, f"(//table[@class='jenkins-table sortable'])[3]/tbody/tr[{number}]/td[3]")
+        plugin_name = self.get_element_text(name_locator)
+        return name_locator, version_locator, enabled_locator, plugin_name

--- a/tests/display_system_information/test_system_information_section.py
+++ b/tests/display_system_information/test_system_information_section.py
@@ -77,11 +77,10 @@ class TestSystemInformationSection:
         number_of_plugins = page.number_of_plugins_in_table(SI.PLUGINS_TABLE_BODY)
         assert number_of_plugins > 0
 
-        for i in range(number_of_plugins):
-            name_locator, version_locator, status_locator, plugin_name = page.get_plugin_info(i + 1)
+        for i in range(1, number_of_plugins+1):
+            name_locator, version_locator, status_locator, plugin_name = page.get_plugin_info(i)
             assert page.is_visible(name_locator), f'Row {i}: Plugin name is not displayed'
             assert page.is_link_clickable(name_locator), f'Row {i}: {plugin_name} is not clickable'
             assert page.is_visible(version_locator), f'Row {i}: {plugin_name} version is not displayed'
             assert page.is_visible(status_locator), f'Row {i}: {plugin_name} status is not displayed'
             assert page.get_element_text(status_locator) in ['true', 'false'], f'Row {i}: {plugin_name} status is not correct'
-

--- a/tests/display_system_information/test_system_information_section.py
+++ b/tests/display_system_information/test_system_information_section.py
@@ -4,6 +4,7 @@ from tests.display_system_information.locators import (
     JenkinsSidePanel as SP,
     ManageJenkinsTask as MJ,
     SystemInformationPage as SI)
+from selenium.webdriver.common.by import By
 
 
 class TestSystemInformationSection:
@@ -70,3 +71,18 @@ class TestSystemInformationSection:
             hide_button = page.define_hide_single_value_button_locator(element_name)
             page.click(hide_button)
             assert page.is_clickable(show_button), f'Button for {element_name} is not clickable'
+
+    def test_plugins_tab_display_plugins_info(self, sys_info_page):
+        page = SIP(sys_info_page)
+        page.click(SI.PLUGINS_TAB)
+        number_of_plugins = page.number_of_plugins_in_table(SI.PLUGINS_TABLE_BODY)
+        assert number_of_plugins > 0
+
+        for i in range(number_of_plugins):
+            name_locator, version_locator, status_locator, plugin_name = page.get_plugin_info(i + 1)
+            assert page.is_visible(name_locator), f'Row {i}: Plugin name is not displayed'
+            assert page.is_link_clickable(name_locator), f'Row {i}: {plugin_name} is not clickable'
+            assert page.is_visible(version_locator), f'Row {i}: {plugin_name} version is not displayed'
+            assert page.is_visible(status_locator), f'Row {i}: {plugin_name} status is not displayed'
+            assert page.get_element_text(status_locator) in ['true', 'false'], f'Row {i}: {plugin_name} status is not correct'
+

--- a/tests/display_system_information/test_system_information_section.py
+++ b/tests/display_system_information/test_system_information_section.py
@@ -4,7 +4,6 @@ from tests.display_system_information.locators import (
     JenkinsSidePanel as SP,
     ManageJenkinsTask as MJ,
     SystemInformationPage as SI)
-from selenium.webdriver.common.by import By
 
 
 class TestSystemInformationSection:


### PR DESCRIPTION
**TC_10.019.06 | Manage Jenkins > Display System Information > "Plugins" tab - display information about installed plugins**

**Preconditions:**
- The user is logged into Jenkins and located on the "System Information" page.
- The active tab is the "Plugins" tab.

**Description:**
Verify that information about installed plugins on the "Plugins" tab is displayed correctly.

**Steps:**
For each installed plugin:
1. Check that the plugin name is displayed.
2. Check that the plugin name is a clickable link to the plugin page.
3. Check that the plugin version is displayed.
4. Check that the enabled/disabled status is displayed as "true" or "false".

**Expected Result:**
Each installed plugin is listed with:
- visible name that is a hyperlink to the plugin page,
- visible version number,
- visible enabled/disabled status (true or false).

**Acceptance Criteria:**
The user should be able to view installed plugins information in Plugins tab.