### PR TITLE
TC_10.019.07 | Manage Jenkins > Display System Information > "Memory Usage" tab - display graph according to the selected Timespan

### DIFF
--- a/tests/display_system_information/locators.py
+++ b/tests/display_system_information/locators.py
@@ -21,3 +21,4 @@ class SystemInformationPage:
     HIDE_SYS_VALUES_BUTTON = (By.XPATH, "(//button[contains(normalize-space(text()), 'Hide values')])[1]")
     HIDE_ENV_VALUES_BUTTON = (By.XPATH, "(//button[contains(normalize-space(text()), 'Hide values')])[2]")
     PLUGINS_TABLE_BODY = (By.XPATH, "(//table[@class='jenkins-table sortable'])[3]/tbody")
+    TIMESPAN_DROPDOWN = (By.ID, 'timespan-select')

--- a/tests/display_system_information/system_information_page.py
+++ b/tests/display_system_information/system_information_page.py
@@ -1,7 +1,9 @@
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import Select
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.remote.webelement import WebElement
 from tests.display_system_information.base_methods import BaseMethods
+from tests.display_system_information.locators import SystemInformationPage as SI
 
 
 class SystemInformationPage(BaseMethods):
@@ -9,6 +11,7 @@ class SystemInformationPage(BaseMethods):
     TAB_TITLE = 'System Information [Jenkins]'
     TABS = ['System Properties', 'Environment Variables', 'Plugins', 'Memory Usage', 'Thread Dumps']
     SYS_ENV_TABS = TABS[:2]
+    TIMESPAN_OPTIONS = {'Short': 'sec10&width', 'Medium': 'min&width', 'Long': 'hour&width'}
 
     def __init__(self, sys_info_page: WebDriver):
         super().__init__(sys_info_page)
@@ -60,3 +63,10 @@ class SystemInformationPage(BaseMethods):
         enabled_locator = (By.XPATH, f"(//table[@class='jenkins-table sortable'])[3]/tbody/tr[{number}]/td[3]")
         plugin_name = self.get_element_text(name_locator)
         return name_locator, version_locator, enabled_locator, plugin_name
+
+    def select_timespan(self, text: str):
+        element = self.get_element(SI.TIMESPAN_DROPDOWN)
+        Select(element).select_by_visible_text(text)
+
+    def get_graph_locator(self, flag_value: str):
+        return By.XPATH, f"//img[@alt='Memory usage graph' and contains(@src, '{flag_value}')]"

--- a/tests/display_system_information/test_system_information_section.py
+++ b/tests/display_system_information/test_system_information_section.py
@@ -84,3 +84,12 @@ class TestSystemInformationSection:
             assert page.is_visible(version_locator), f'Row {i}: {plugin_name} version is not displayed'
             assert page.is_visible(status_locator), f'Row {i}: {plugin_name} status is not displayed'
             assert page.get_element_text(status_locator) in ['true', 'false'], f'Row {i}: {plugin_name} status is not correct'
+
+    def test_memory_usage_tab_select_timespan(self, sys_info_page):
+        page = SIP(sys_info_page)
+        page.click(SI.MEMORY_USAGE_TAB)
+        for option in page.TIMESPAN_OPTIONS:
+            page.click(SI.TIMESPAN_DROPDOWN)
+            page.select_timespan(option)
+            graph = page.get_graph_locator(page.TIMESPAN_OPTIONS.get(option))
+            assert page.is_visible(graph), f"Graph for timespan option '{option}' is not displayed, or displayed incorrectly"


### PR DESCRIPTION
**TC_10.019.07 | Manage Jenkins > Display System Information > "Memory Usage" tab - display graph according to the selected timespan**

**Preconditions:**
- The user is logged into Jenkins and located on the "System Information" page.
- The active tab is the "Memory Usage" tab.

**Description:**
Verify that the memory usage graph is displayed according to the selected timespan.

**Steps:**
1. Select "Short" Timespan.
2. Check that the graph is displayed and the graph's X-axis is scaled to 3 min 20 sec.
3. Select "Medium" Timespan.
4. Check that the graph is displayed and the graph's X-axis is scaled to 12 min.
5. Select "Long" Timespan.
6. Check that the graph is displayed and the graph's X-axis is scaled to 1 hour.

**Expected Result:**
The scale of the graph's X-axis changes depending on the selected Timespan:
- Short - 3 min 20 sec,
- Medium - 12 min,
- Long - 1 hour.

**Acceptance Criteria:**
User should be able to review memory usage data as a graph and select a timespan.