### PR TITLE
TC_10.019.08 | Manage Jenkins > Display System Information > "Thread Dumps" tab - open "Thread Dump" page

### DIFF
--- a/tests/display_system_information/locators.py
+++ b/tests/display_system_information/locators.py
@@ -22,3 +22,4 @@ class SystemInformationPage:
     HIDE_ENV_VALUES_BUTTON = (By.XPATH, "(//button[contains(normalize-space(text()), 'Hide values')])[2]")
     PLUGINS_TABLE_BODY = (By.XPATH, "(//table[@class='jenkins-table sortable'])[3]/tbody")
     TIMESPAN_DROPDOWN = (By.ID, 'timespan-select')
+    THREAD_DUMP_LINK = (By.XPATH, "//a[@href='threadDump']")

--- a/tests/display_system_information/system_information_page.py
+++ b/tests/display_system_information/system_information_page.py
@@ -8,9 +8,7 @@ from tests.display_system_information.locators import SystemInformationPage as S
 
 class SystemInformationPage(BaseMethods):
     ENDPOINT_URL = '/manage/systemInfo'
-    TAB_TITLE = 'System Information [Jenkins]'
-    TABS = ['System Properties', 'Environment Variables', 'Plugins', 'Memory Usage', 'Thread Dumps']
-    SYS_ENV_TABS = TABS[:2]
+    THREAD_DUMP_TITLE = 'Thread dump [Jenkins]'
     TIMESPAN_OPTIONS = {'Short': 'sec10&width', 'Medium': 'min&width', 'Long': 'hour&width'}
 
     def __init__(self, sys_info_page: WebDriver):

--- a/tests/display_system_information/test_system_information_section.py
+++ b/tests/display_system_information/test_system_information_section.py
@@ -93,3 +93,9 @@ class TestSystemInformationSection:
             page.select_timespan(option)
             graph = page.get_graph_locator(page.TIMESPAN_OPTIONS.get(option))
             assert page.is_visible(graph), f"Graph for timespan option '{option}' is not displayed, or displayed incorrectly"
+
+    def test_thread_dumps_tab_open_thread_dump_page(self, sys_info_page):
+        page = SIP(sys_info_page)
+        page.click(SI.THREAD_DUMPS_TAB)
+        page.click(SI.THREAD_DUMP_LINK)
+        assert page.driver.title == SIP.THREAD_DUMP_TITLE


### PR DESCRIPTION
**TC_10.019.08 | Manage Jenkins > Display System Information > "Thread Dumps" tab - open "Thread Dump" page**

**Preconditions:**
- The user is logged into Jenkins and located on the "System Information" page.
- The active tab is the "Thread Dumps" tab.

**Description:**
Verify that the page with thread dump information opens from the "Thread Dumps" tab.

**Steps:**
1. Click on "this page" link inside the "Thread Dumps" tab.
2. Verify that the user was redirected to the thread dump information page.

**Expected Result:**
The user redirected to the "Thread Dump" page.

**Acceptance Criteria:**
The user should be able to view thread dump information for debugging purposes.