### PR TITLE
TC_04.001.05 | Multi-configuration project Configuration > Enable or Disable the Project > Switch button state reflects actual project state after saving and navigation

### DIFF
--- a/pages/multi_config_project_page.py
+++ b/pages/multi_config_project_page.py
@@ -1,5 +1,7 @@
-from pages.base_page import BasePage
+import allure
 from selenium.webdriver.common.by import By
+
+from pages.base_page import BasePage
 
 
 class MultiConfigProjectPage(BasePage):
@@ -11,10 +13,12 @@ class MultiConfigProjectPage(BasePage):
         WARNING_MESSAGE = (By.ID, "enable-project")
         ENABLE_BUTTON = (By.XPATH, "//form[@id='enable-project']//button")
         PROJECT_STATUS_ICON = (By.CSS_SELECTOR, "#matrix svg.icon-md")
+        CONFIGURE_MENU_ITEM = (By.XPATH, "//span[text()='Configure']/..")
 
     def __init__(self, driver, name, timeout=5):
         super().__init__(driver, timeout=timeout)
         self.url = self.base_url + f"/job/{name}/"
+        self.name = name
 
     def get_saved_description_text(self):
         return self.wait_to_be_visible(self.Locators.SAVED_DESCRIPTION).text
@@ -39,3 +43,9 @@ class MultiConfigProjectPage(BasePage):
 
     def get_project_status_title(self) -> str:
         return self.wait_and_get_attribute(self.Locators.PROJECT_STATUS_ICON, "title")
+
+    def go_to_configure_page(self):
+        with allure.step(f'Go to Configure page of project "{self.name}"'):
+            from pages.multi_config_project_config_page import MultiConfigProjectConfigPage
+            self.click_on(self.Locators.CONFIGURE_MENU_ITEM)
+            return MultiConfigProjectConfigPage(self.driver, self.name).wait_for_url()

--- a/tests/multi_config/test_enable_disable_project.py
+++ b/tests/multi_config/test_enable_disable_project.py
@@ -44,3 +44,14 @@ def test_disappear_warning_message(page_disabled_multi_config_project):
         f"Warning message {ProjectToggle.WARNING_MESSAGE} did not disappear"
     assert page.get_project_status_title() == ProjectToggle.STATUS_NOT_BUILT, \
         f"Expected project status '{ProjectToggle.STATUS_NOT_BUILT}' NOT FOUND"
+
+
+@allure.epic("Multi-configuration project Configuration")
+@allure.story("Enable or Disable the Project")
+@allure.title("Switch button state reflects actual project state after saving and navigation")
+@allure.testcase("TC_04.001.05")
+@allure.link("https://github.com/RedRoverSchool/JenkinsQA_Python_2025_spring/issues/741", name="Github issue")
+def test_config_switch_state_after_save(page_disabled_multi_config_project):
+    config_page = page_disabled_multi_config_project.go_to_configure_page()
+
+    assert config_page.is_project_disabled(), "The project is not disabled"

--- a/tests/multi_config/test_enable_disable_project.py
+++ b/tests/multi_config/test_enable_disable_project.py
@@ -51,7 +51,7 @@ def test_disappear_warning_message(page_disabled_multi_config_project):
 @allure.title("Switch button state reflects actual project state after saving and navigation")
 @allure.testcase("TC_04.001.05")
 @allure.link("https://github.com/RedRoverSchool/JenkinsQA_Python_2025_spring/issues/741", name="Github issue")
-def test_config_switch_state_after_save(page_disabled_multi_config_project):
+def test_switch_state_persists_after_save_and_navigation(page_disabled_multi_config_project):
     config_page = page_disabled_multi_config_project.go_to_configure_page()
 
     assert config_page.is_project_disabled(), "The project is not disabled"


### PR DESCRIPTION
https://github.com/RedRoverSchool/JenkinsQA_Python_2025_spring/issues/741